### PR TITLE
Include `depfoo` label in Merge Requests

### DIFF
--- a/lib/depfoo/open_merge_request.rb
+++ b/lib/depfoo/open_merge_request.rb
@@ -11,7 +11,7 @@ module Depfoo
     end
 
     def call
-      Faraday.post(@gitlab_url, { state: 'opened' },
+      Faraday.post(@gitlab_url, { state: 'opened', labels: 'depfoo' },
                    { 'Content-Type' => 'application/json', 'PRIVATE-TOKEN' => @token }) do |req|
         req.body = @data
       end


### PR DESCRIPTION
Adds the label `depfoo` to the Merge Requests depfoo creates so it's possible to quickly hotlink those MR's.