### PR TITLE
Use explicit dependencies from Gemfile

### DIFF
--- a/lib/depfoo/bundle/outdated_gems.rb
+++ b/lib/depfoo/bundle/outdated_gems.rb
@@ -20,7 +20,7 @@ module Depfoo
     private
 
     def bundle_command_line
-      `bundle outdated --parseable --#{@working_mode} #{@gem}`
+      `bundle outdated --only-explicit --parseable --#{@working_mode} #{@gem}`
     end
   end
 end


### PR DESCRIPTION
This makes depfoo report on updates on dependencies tracked explicitly in Gemfile instead of all dependencies (including transitive dependencies).

By using this mode, a rails update will not longer be pushed via 7+ separate pullrequest (action*,active*,railties) including the rails update itself.